### PR TITLE
fix: map charging_active and charging_ready to ChargeStateCharging

### DIFF
--- a/internal/rivian/vehicles.go
+++ b/internal/rivian/vehicles.go
@@ -408,7 +408,7 @@ func areAllDoorsLocked(apiState vehicleStateData) bool {
 // parseChargeState converts API charge status string to ChargeState enum.
 func parseChargeState(status string) ChargeState {
 	switch status {
-	case "charging", "charging_active", "charging_ready":
+	case "charging", "charging_active":
 		return ChargeStateCharging
 	case "complete", "fully_charged", "charging_complete":
 		return ChargeStateComplete
@@ -416,7 +416,7 @@ func parseChargeState(status string) ChargeState {
 		return ChargeStateScheduled
 	case "disconnected", "not_connected":
 		return ChargeStateDisconnected
-	case "not_charging", "stopped":
+	case "not_charging", "stopped", "charging_ready":
 		return ChargeStateNotCharging
 	case "":
 		// Empty string means disconnected/not plugged in

--- a/internal/rivian/vehicles.go
+++ b/internal/rivian/vehicles.go
@@ -408,7 +408,7 @@ func areAllDoorsLocked(apiState vehicleStateData) bool {
 // parseChargeState converts API charge status string to ChargeState enum.
 func parseChargeState(status string) ChargeState {
 	switch status {
-	case "charging":
+	case "charging", "charging_active", "charging_ready":
 		return ChargeStateCharging
 	case "complete", "fully_charged", "charging_complete":
 		return ChargeStateComplete

--- a/internal/rivian/vehicles_test.go
+++ b/internal/rivian/vehicles_test.go
@@ -285,6 +285,7 @@ func TestParseChargeState(t *testing.T) {
 		want  ChargeState
 	}{
 		{"charging", ChargeStateCharging},
+		{"charging_active", ChargeStateCharging},
 		{"complete", ChargeStateComplete},
 		{"fully_charged", ChargeStateComplete},
 		{"charging_complete", ChargeStateComplete},
@@ -293,6 +294,7 @@ func TestParseChargeState(t *testing.T) {
 		{"not_connected", ChargeStateDisconnected},
 		{"not_charging", ChargeStateNotCharging},
 		{"stopped", ChargeStateNotCharging},
+		{"charging_ready", ChargeStateNotCharging},
 		{"unknown_status", ChargeStateUnknown},
 		{"", ChargeStateDisconnected},
 	}


### PR DESCRIPTION
The Rivian API returns `charging_active` during active charging and `charging_ready` when plugged in but not yet charging. Neither were in `parseChargeState`, causing them to fall through to `ChargeStateUnknown` with a stderr warning. Adds both to the charging case.