### PR TITLE
fix: restore saved OTP session for phase-2 login

### DIFF
--- a/cmd/rivian-ls/main.go
+++ b/cmd/rivian-ls/main.go
@@ -263,19 +263,14 @@ func completePendingOTP(ctx context.Context, client *rivian.HTTPClient, credCach
 		return fmt.Errorf("no valid pending OTP session")
 	}
 
-	// Create a fresh CSRF session BEFORE submitting OTP. This is critical because:
-	// 1. It establishes session cookies in the HTTP client's cookie jar (the jar is
-	//    empty since this is a new process — Phase 1's cookies died with that process)
-	// 2. The loginWithOTP mutation accepts the otpToken as a GraphQL argument, so it
-	//    doesn't need to be paired with Phase 1's specific CSRF session
-	if err := client.CreateSession(ctx); err != nil {
-		return fmt.Errorf("create session: %w", err)
-	}
-
+	// Restore the exact OTP-bound session from phase 1.
+	// Rivian appears to bind otpToken to the original csrf-token/a-sess pair,
+	// so replacing it with a freshly created session can cause
+	// "User is unauthenticated" during loginWithOTP.
+	client.SetSessionTokens(pending.CSRFToken, pending.AppSessionID)
 	client.SetOTPState(pending.OTPToken, pending.Email)
 
 	if err := client.SubmitOTP(ctx, otpCode); err != nil {
-		_ = credCache.DeletePendingOTP()
 		return fmt.Errorf("OTP submission failed: %w", err)
 	}
 

--- a/cmd/rivian-ls/main_test.go
+++ b/cmd/rivian-ls/main_test.go
@@ -2,9 +2,19 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/pfrederiksen/rivian-ls/internal/auth"
+	"github.com/pfrederiksen/rivian-ls/internal/rivian"
 )
 
 // errorWriter always returns an error when Write is called
@@ -154,5 +164,150 @@ func TestHasFlag(t *testing.T) {
 				t.Errorf("hasFlag(%v, %q) = %v, want %v", tt.args, tt.flag, got, tt.expect)
 			}
 		})
+	}
+}
+
+func TestCompletePendingOTP_RestoresSavedSession(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	credCache, err := auth.NewCredentialsCache()
+	if err != nil {
+		t.Fatalf("NewCredentialsCache failed: %v", err)
+	}
+
+	pending := &auth.PendingOTP{
+		Email:        "test@example.com",
+		OTPToken:     "otp-token-123",
+		CSRFToken:    "saved-csrf-token",
+		AppSessionID: "saved-app-session",
+	}
+	if err := credCache.SavePendingOTP(pending); err != nil {
+		t.Fatalf("SavePendingOTP failed: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request failed: %v", err)
+		}
+
+		if got := r.Header.Get("a-sess"); got != pending.AppSessionID {
+			t.Errorf("expected a-sess %q, got %q", pending.AppSessionID, got)
+		}
+		if got := r.Header.Get("csrf-token"); got != pending.CSRFToken {
+			t.Errorf("expected csrf-token %q, got %q", pending.CSRFToken, got)
+		}
+
+		variables, _ := req["variables"].(map[string]any)
+		if got := variables["email"]; got != pending.Email {
+			t.Errorf("expected email %q, got %v", pending.Email, got)
+		}
+		if got := variables["otpCode"]; got != "123456" {
+			t.Errorf("expected otpCode %q, got %v", "123456", got)
+		}
+		if got := variables["otpToken"]; got != pending.OTPToken {
+			t.Errorf("expected otpToken %q, got %v", pending.OTPToken, got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"loginWithOTP": map[string]any{
+					"__typename":       "MobileLoginResponse",
+					"accessToken":      "unused-access-token",
+					"refreshToken":     "refresh-token",
+					"userSessionToken": "user-session-token",
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := rivian.NewHTTPClient(rivian.WithBaseURL(server.URL))
+
+	if err := completePendingOTP(context.Background(), client, credCache, "123456"); err != nil {
+		t.Fatalf("completePendingOTP failed: %v", err)
+	}
+
+	if client.GetCSRFToken() != pending.CSRFToken {
+		t.Errorf("expected restored CSRF token %q, got %q", pending.CSRFToken, client.GetCSRFToken())
+	}
+	if client.GetAppSessionID() != pending.AppSessionID {
+		t.Errorf("expected restored app session %q, got %q", pending.AppSessionID, client.GetAppSessionID())
+	}
+
+	if loadedPending, err := credCache.LoadPendingOTP(); err != nil {
+		t.Fatalf("LoadPendingOTP failed: %v", err)
+	} else if loadedPending != nil {
+		t.Fatalf("expected pending OTP to be deleted after success, got %+v", loadedPending)
+	}
+
+	loadedCreds, err := credCache.Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if loadedCreds == nil {
+		t.Fatal("expected saved credentials, got nil")
+	}
+	if loadedCreds.Email != pending.Email {
+		t.Errorf("expected saved email %q, got %q", pending.Email, loadedCreds.Email)
+	}
+	if loadedCreds.AccessToken != "user-session-token" {
+		t.Errorf("expected saved access token %q, got %q", "user-session-token", loadedCreds.AccessToken)
+	}
+}
+
+func TestCompletePendingOTP_KeepsPendingSessionOnFailure(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	credCache, err := auth.NewCredentialsCache()
+	if err != nil {
+		t.Fatalf("NewCredentialsCache failed: %v", err)
+	}
+
+	pending := &auth.PendingOTP{
+		Email:        "test@example.com",
+		OTPToken:     "otp-token-123",
+		CSRFToken:    "saved-csrf-token",
+		AppSessionID: "saved-app-session",
+		SavedAt:      time.Now(),
+	}
+	if err := credCache.SavePendingOTP(pending); err != nil {
+		t.Fatalf("SavePendingOTP failed: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"errors": []map[string]any{
+				{"message": "User is unauthenticated"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := rivian.NewHTTPClient(rivian.WithBaseURL(server.URL))
+
+	err = completePendingOTP(context.Background(), client, credCache, "123456")
+	if err == nil {
+		t.Fatal("expected completePendingOTP to fail")
+	}
+	if !strings.Contains(err.Error(), "OTP submission failed") {
+		t.Fatalf("expected OTP submission failure, got %v", err)
+	}
+
+	loadedPending, err := credCache.LoadPendingOTP()
+	if err != nil {
+		t.Fatalf("LoadPendingOTP failed: %v", err)
+	}
+	if loadedPending == nil {
+		t.Fatal("expected pending OTP session to remain after failure")
+	}
+	if loadedPending.CSRFToken != pending.CSRFToken || loadedPending.AppSessionID != pending.AppSessionID {
+		t.Fatalf("pending OTP session changed after failure: %+v", loadedPending)
+	}
+
+	if _, err := os.Stat(filepath.Join(filepath.Dir(credCache.Path()), "pending_otp.json")); err != nil {
+		t.Fatalf("expected pending_otp.json to remain on disk, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Fix two-phase OTP login by restoring the saved OTP-bound session from `pending_otp.json` instead of replacing it with a fresh session before `SubmitOTP()`.

## Problem

Phase 1 persists:
- `otpToken`
- `csrfToken`
- `appSessionID`
- `email`

But phase 2 was doing this:
1. load pending OTP state
2. call `CreateSession()`
3. overwrite CSRF/app-session with a fresh pair
4. submit OTP

That appears to break the binding between the saved `otpToken` and the original session headers, causing Rivian to return:

- `graphql error: User is unauthenticated`

## Fix

In `completePendingOTP()`:
- restore `csrfToken` + `appSessionID` from pending OTP state
- restore `otpToken` + `email`
- submit OTP against that original session
- stop creating a fresh session right before OTP submission

## Related

Closes / relates to:
- issue #15
